### PR TITLE
Fix distributed dataset schedule desync

### DIFF
--- a/train.py
+++ b/train.py
@@ -98,6 +98,7 @@ def parse_args(args):
     parser.add_argument("--train_mask_decoder", action="store_true", default=True)
     parser.add_argument("--use_mm_start_end", action="store_true", default=True)
     parser.add_argument("--print_freq", default=1, type=int)
+    parser.add_argument("--seed", default=42, type=int)
     parser.add_argument("--start_epoch", default=0, type=int)
     parser.add_argument("--local_rank", default=0, type=int, help="node rank")
 
@@ -455,14 +456,15 @@ def main(args):
         cur_val_loss = validate_model_performance(val_loader, model_engine, 0, writer, args)[0]
         exit()
 
-    epoch_seeds = [random.randint(0, 100000) for _ in range(args.epochs)]
     dataset_choices = [idx for idx, _ in enumerate(active_dataloaders)]
 
     best_giou, best_ciou, best_val_loss = 0.0, 0.0, np.inf
     for epoch in range(args.start_epoch, args.epochs):
-        random.seed(epoch_seeds[epoch])
-
-        step_choices = random.choices(dataset_choices, weights=weights, k=args.steps_per_epoch)
+        # Keep the dataset schedule identical across ranks. Different dataset
+        # types exercise different model branches, so per-rank schedules can
+        # desynchronize ZeRO gradient communication during backward.
+        epoch_rng = random.Random(args.seed + epoch)
+        step_choices = epoch_rng.choices(dataset_choices, weights=weights, k=args.steps_per_epoch)
 
         dataset_iters = train(
             active_dataloaders, model_engine, epoch, scheduler, writer, dataset_iters, args, step_choices


### PR DESCRIPTION
Distributed training with DeepSpeed expects every rank to execute the same collective communication pattern during backward. The mixed training loop samples one of several dataset groups per optimizer step, and those groups do not all exercise the same model branches: caption, region, and segmentation batches can produce different sets of used trainable parameters.

Previously each rank generated its own random epoch seeds before sampling step_choices. In multi-GPU runs this can make rank 0 process one dataset type while rank 1 processes another at the same global step. When the activated branches differ, ZeRO gradient reduction can desynchronize and training appears to hang inside model.backward().

Add a stable --seed argument and derive the per-epoch dataset schedule from random.Random(args.seed + epoch). This keeps the weighted dataset sampling behavior, but makes the selected dataset type deterministic and identical across ranks for each epoch/step.

A short 2-GPU smoke test confirmed that both ranks completed forward, backward, and optimizer step for segmentation, caption, and region batches with the deterministic schedule.